### PR TITLE
Fix: annotate model after .mat and .yml export, but before .xml export

### DIFF
--- a/code/masterScriptFruitflyGEM.m
+++ b/code/masterScriptFruitflyGEM.m
@@ -44,10 +44,10 @@ if isequal(rxnAssoc.rxns, fruitflyGEM.rxns) && isequal(metAssoc.mets, fruitflyGE
     exportTsvFile(metAssoc,'../model/metabolites.tsv');
 end
 
-fruitflyGEM = annotateGEM(fruitflyGEM,'../model',{'rxn','met'});  % add annotation data to structure
-fruitflyGEM.id = regexprep(fruitflyGEM.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
 save('../model/Fruitfly-GEM.mat', 'fruitflyGEM');
 exportYaml(fruitflyGEM, '../model/Fruitfly-GEM.yml');
+fruitflyGEM = annotateGEM(fruitflyGEM,'../model',{'rxn','met'});  % add annotation data to structure
+fruitflyGEM.id = regexprep(fruitflyGEM.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
 fruitflyGEM.genes = strcat('G_',fruitflyGEM.genes);
 exportModel(fruitflyGEM, '../model/Fruitfly-GEM.xml');
 


### PR DESCRIPTION
### Main improvements in this PR:
As described in [Issue 16 of Mouse-GEM](https://github.com/SysBioChalmers/Mouse-GEM/issues/16) and addressed in PR [18](https://github.com/SysBioChalmers/Mouse-GEM/pull/18) of that same repo, the master script for regenerating the model files (`masterScriptFruitflyGEM.m` in this repo) is modified such that the addition of non-standard metabolite and reaction annotation fields are only added to the SBML (`.xml`) version of the model. The `.mat` and `.yml` versions should not contain these fields.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch